### PR TITLE
Path matcher bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Master
 
+2.2.4 - 15 March, 2021
+
+#### Fixes
+-  Prioritize exact path segment matching
+
+
 # 2.2.3 - 23 January 2021
  - a fixed bug: when response is with additionalProperties false,
    The error was not shown or was not fit to specific field.

--- a/lib/helpers/coverage.js
+++ b/lib/helpers/coverage.js
@@ -43,7 +43,7 @@ module.exports.setCoverage = ({ path, method, status }) => {
     return;
   }
 
-  const route = schemaUtils.pathMatcher(schema, path);
+  const route = schemaUtils.pathMatcher(schema, path, method);
 
   set(coverage, `[${route}|${method}|${status}]`, true);
 };

--- a/lib/helpers/schema-utils.js
+++ b/lib/helpers/schema-utils.js
@@ -35,14 +35,20 @@ module.exports.getSchemaByFilesPath = (apiDefinitionsPath, buildSchemaOptions) =
 };
 
 module.exports.getValidatorByPathMethodAndCode = (schema, request, response) => {
-  const route = pathMatcher(schema, request.path);
+  const route = pathMatcher(schema, request.path, request.method);
   return get(schema, `${route}.${request.method}.responses.${response.status}`);
 };
 
 module.exports.pathMatcher = pathMatcher;
-function pathMatcher(routes, path) {
+function pathMatcher(routes, path, method) {
   return Object
     .keys(routes)
+    .sort((currentRoute, nextRoute) => {
+      const firstResult = calculateRouteScore(currentRoute);
+      const secondResult = calculateRouteScore(nextRoute);
+
+      return firstResult - secondResult;
+    })
     .filter((route) => {
       const routeArr = route.split('/');
       const pathArr = path.split('/');
@@ -57,5 +63,16 @@ function pathMatcher(routes, path) {
 
         return false;
       });
-    })[0];
+    }).filter(((route) => routes[route][String(method).toLowerCase()]))[0];
+}
+
+function calculateRouteScore(route) {
+  return route
+  // split to path segments
+    .split('/')
+  // mark path params locations
+    .map((pathSegment) => pathSegment.includes(':'))
+  // give weight to each path segment according to its location
+    .map((isPathParam, i, pathSegments) => isPathParam * (10 ** pathSegments.length - i))
+    .reduce((sum, seg) => sum + seg, 0); // summarize the path score
 }

--- a/test/path-matcher.test.js
+++ b/test/path-matcher.test.js
@@ -1,0 +1,92 @@
+const { expect } = require('chai');
+
+const { pathMatcher } = require('../lib/helpers/schema-utils');
+
+
+describe('path matcher test', () => {
+  it('basic - when schema has only one path /api/v1/sar/reports/:requestId/:otherId '
+      + 'and request is /api/v1/sar/reports/bulk/7127836128736 should match', () => {
+    const routes = {
+      '/api/v1/sar/reports/:requestId/:otherId': { post: 'validator' },
+    };
+    const routeResult = pathMatcher(routes, '/api/v1/sar/reports/bulk/7127836128736', 'post');
+    expect(routeResult).equals('/api/v1/sar/reports/:requestId/:otherId');
+  });
+  it('when there is no match method request - should return undefined', () => {
+    const routes = {
+      '/api/v1/sar/reports/:requestId/:otherId': { get: 'validator' },
+    };
+    const routeResult = pathMatcher(routes, '/api/v1/sar/reports/bulk/7127836128736', 'post');
+    expect(routeResult).equals(undefined);
+  });
+  describe('when routes includes both /api/v1/sar/reports/:requestId vs /api/v1/sar/reports/bulk', () => {
+    const routes = {
+      '/api/v1/sar/reports/:requestId': { post: 'validator-requestId' },
+      '/api/v1/sar/reports/bulk': { post: 'validator-requestId' },
+    };
+    it('and request url is /api/v1/sar/reports/bulk - should take the exact match /api/v1/sar/reports/bulk', () => {
+      const routeResult = pathMatcher(routes, '/api/v1/sar/reports/bulk', 'post');
+      expect(routeResult).equals('/api/v1/sar/reports/bulk');
+    });
+    it('and request url is /api/v1/sar/reports/7127836128736 - should returns /api/v1/sar/reports/:requestId route', () => {
+      const routeResult = pathMatcher(routes, '/api/v1/sar/reports/7127836128736', 'post');
+      expect(routeResult).equals('/api/v1/sar/reports/:requestId');
+    });
+  });
+
+  describe('when routes includes both /api/v1/sar/reports/:requestId/:otherId vs /api/v1/sar/reports/bulk/:other', () => {
+    const routes = {
+      '/api/v1/sar/reports/:requestId/:otherId': { post: 'validator-requestId' },
+      '/api/v1/sar/reports/bulk/:other': { post: 'validator-requestId' },
+    };
+
+    it('and request url is /api/v1/sar/reports/bulk/7127836128736 - should take the match /api/v1/sar/reports/bulk/:other', () => {
+      const routeResult = pathMatcher(routes, '/api/v1/sar/reports/bulk/7127836128736', 'post');
+      expect(routeResult).equals('/api/v1/sar/reports/bulk/:other');
+    });
+    it('and request url is /api/v1/sar/reports/7127836128736/7127836128736 - should returns /api/v1/sar/reports/:requestId/:otherId route', () => {
+      const routeResult = pathMatcher(routes, '/api/v1/sar/reports/7127836128736/7127836128736', 'post');
+      expect(routeResult).equals('/api/v1/sar/reports/:requestId/:otherId');
+    });
+  });
+
+  describe('when routes includes both /i/am/:here vs /i/:am/:here', () => {
+    const routes = {
+      '/i/am/:here': { post: 'validator-requestId' },
+      '/i/:am/:here': { post: 'validator-requestId' },
+    };
+
+    it('and request url is /i/am/blblb - should match /i/am/:here', () => {
+      const routeResult = pathMatcher(routes, '/i/am/blblb', 'post');
+      expect(routeResult).equals('/i/am/:here');
+    });
+    it('and request url is /i/bbb/blblb - should match /i/:am/:here', () => {
+      const routeResult = pathMatcher(routes, '/i/bbb/blbl', 'post');
+      expect(routeResult).equals('/i/:am/:here');
+    });
+  });
+  describe('when routes includes both /i/:am/:here vs /i/:am/here', () => {
+    const routes = {
+      '/i/:am/:here': { post: 'validator-requestId' },
+      '/i/:am/here': { post: 'validator-requestId' },
+    };
+    it('and request url is /i/am/blblb - should match /i/:am/:here', () => {
+      const routeResult = pathMatcher(routes, '/i/am/blblb', 'post');
+      expect(routeResult).equals('/i/:am/:here');
+    });
+    it('and request url is /i/bbb/here - should match /i/:am/here', () => {
+      const routeResult = pathMatcher(routes, '/i/bbb/here', 'post');
+      expect(routeResult).equals('/i/:am/here');
+    });
+  });
+  describe('when routes includes both /aaaa/:bbbb vs /:aaaa/bbbb', () => {
+    const routes = {
+      '/aaaa/:bbbb': { post: 'validator-requestId' },
+      '/:aaaa/bbbb': { post: 'validator-requestId' },
+    };
+    it('and request url is /aaaa/bbbb - should match /aaaa/:bbbb', () => {
+      const routeResult = pathMatcher(routes, '/aaaa/bbbb', 'post');
+      expect(routeResult).equals('/aaaa/:bbbb');
+    });
+  });
+});


### PR DESCRIPTION
path matcher faild to match to correct schema key when the routes are:
/api/v1/sar/reports/:requestId
/api/v1/sar/reports/bulk

(in yaml)

for request to path /api/v1/sar/reports/bulk, it match /api/v1/sar/reports/:requested.

